### PR TITLE
a protential bug

### DIFF
--- a/src/main/scala/Datapath.scala
+++ b/src/main/scala/Datapath.scala
@@ -49,7 +49,7 @@ class Datapath(implicit val p: Parameters) extends Module with CoreParams {
  
   /****** Fetch *****/
   val started = RegNext(reset.toBool)
-  val stall = !io.icache.resp.valid || !io.dcache.resp.valid
+  val stall = !io.icache.resp.valid && !io.dcache.resp.valid
   val pc   = RegInit(Const.PC_START.U(xlen.W) - 4.U(xlen.W))
   val npc  = Mux(stall, pc, Mux(csr.io.expt, csr.io.evec,
              Mux(io.ctrl.pc_sel === PC_EPC,  csr.io.epc,


### PR DESCRIPTION
Hello, Kim. When I reading your code, encountered this question:
https://github.com/ucb-bar/riscv-mini/blob/4cbbf6cd2f1e63eefebd082cd52eddd0f63b0a26/src/main/scala/Datapath.scala#L52
why should stall be `val stall: Bool = !io.icache.resp.valid || !io.dcache.resp.valid`, rather than `val stall: Bool = !io.icache.resp.valid && !io.dcache.resp.valid`, for example, if `icache` is not valid, and `dcache` is valid, `inst` here
https://github.com/ucb-bar/riscv-mini/blob/4cbbf6cd2f1e63eefebd082cd52eddd0f63b0a26/src/main/scala/Datapath.scala#L58
will fetch a unstable instruction from `icache`, and because `stall` is false, pipeline won't stall, which may cause a fetch error.