### PR TITLE
Support pure chisel3 (3.2-SNAPSHOT)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,29 @@
+// Deal with potential problems with anonymous class structural definitions in Scala > 2.11
+def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
+  Seq() ++ {
+    // If we're building with Scala > 2.11, enable the compile option
+    //  switch to support our anonymous Bundle definitions:
+    //  https://github.com/scala/bug/issues/10047
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
+      case _ => Seq("-Xsource:2.11")
+    }
+  }
+}
+
+// Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
+// The following are the default development versions, not the "release" versions.
+val defaultVersions = Map("chisel3" -> "3.2-SNAPSHOT")
+
 val commonSettings = Seq(
   scalaVersion := "2.12.4",
   crossScalaVersions := Seq("2.11.12", "2.12.4"),
+  scalacOptions := scalacOptionsVersion(scalaVersion.value),
+  libraryDependencies ++= Seq("chisel3").map { dep: String =>
+    "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
+  },
   libraryDependencies ++= Seq(
-    "edu.berkeley.cs" %% "chisel3" % "3.1.0",
-    "org.scalatest" %% "scalatest" % "3.0.1"
+    "org.scalatest" %% "scalatest" % "3.0.5"
   ),
   resolvers ++= Seq(
     Resolver.sonatypeRepo("snapshots"),

--- a/src/main/scala/Cache.scala
+++ b/src/main/scala/Cache.scala
@@ -51,7 +51,6 @@ class MetaData(implicit val p: Parameters) extends Bundle with CacheParams {
 }
 
 class Cache(implicit val p: Parameters) extends Module with CacheParams {
-  import Chisel._ // FIXME: read enable signals for memories are broken by new chisel
   val io = IO(new CacheModuleIO)
   // cache states
   val (s_IDLE :: s_READ_CACHE :: s_WRITE_CACHE :: s_WRITE_BACK :: s_WRITE_ACK ::
@@ -60,8 +59,8 @@ class Cache(implicit val p: Parameters) extends Module with CacheParams {
   // memory
   val v        = RegInit(0.U(nSets.W))
   val d        = RegInit(0.U(nSets.W))
-  val metaMem  = SeqMem(nSets, new MetaData)
-  val dataMem  = Seq.fill(nWords)(SeqMem(nSets, Vec(wBytes, UInt(8.W))))
+  val metaMem  = SyncReadMem(nSets, new MetaData)
+  val dataMem  = Seq.fill(nWords)(SyncReadMem(nSets, Vec(wBytes, UInt(8.W))))
 
   val addr_reg = Reg(io.cpu.req.bits.addr.cloneType)
   val cpu_data = Reg(io.cpu.req.bits.data.cloneType)
@@ -98,7 +97,7 @@ class Cache(implicit val p: Parameters) extends Module with CacheParams {
   hit := v(idx_reg) && rmeta.tag === tag_reg 
 
   // Read Mux
-  io.cpu.resp.bits.data := Vec.tabulate(nWords)(i => read((i+1)*xlen-1, i*xlen))(off_reg)
+  io.cpu.resp.bits.data := VecInit.tabulate(nWords)(i => read((i+1)*xlen-1, i*xlen))(off_reg)
   io.cpu.resp.valid     := is_idle || is_read && hit || is_alloc_reg && !cpu_mask.orR
 
   when(io.cpu.resp.valid) { 
@@ -110,7 +109,7 @@ class Cache(implicit val p: Parameters) extends Module with CacheParams {
   val wmeta = Wire(new MetaData)
   wmeta.tag := tag_reg
 
-  val wmask = Mux(!is_alloc, (cpu_mask << Cat(off_reg, 0.U(byteOffsetBits.W))).zext, SInt(-1))
+  val wmask = Mux(!is_alloc, ((cpu_mask << Cat(off_reg, 0.U(byteOffsetBits.W)))).asUInt.zext, (-1).S)
   val wdata = Mux(!is_alloc, Fill(nWords, cpu_data), 
     if (refill_buf.size == 1) io.nasti.r.bits.data
     else Cat(io.nasti.r.bits.data, Cat(refill_buf.init.reverse)))
@@ -121,14 +120,14 @@ class Cache(implicit val p: Parameters) extends Module with CacheParams {
       metaMem.write(idx_reg, wmeta)
     }
     dataMem.zipWithIndex foreach { case (mem, i) =>
-      val data = Vec.tabulate(wBytes)(k => wdata(i*xlen+(k+1)*8-1, i*xlen+k*8))
-      mem.write(idx_reg, data, wmask((i+1)*wBytes-1, i*wBytes).toBools)
+      val data = VecInit.tabulate(wBytes)(k => wdata(i*xlen+(k+1)*8-1, i*xlen+k*8))
+      mem.write(idx_reg, data, wmask((i+1)*wBytes-1, i*wBytes).asBools)
       mem suggestName s"dataMem_${i}"
     }
   }
 
   io.nasti.ar.bits := NastiReadAddressChannel(
-    0.U, Cat(tag_reg, idx_reg) << blen.U, log2Up(nastiXDataBits/8).U, (dataBeats-1).U)
+    0.U, (Cat(tag_reg, idx_reg) << blen.U).asUInt, log2Up(nastiXDataBits/8).U, (dataBeats-1).U)
   io.nasti.ar.valid := false.B
   // read data
   io.nasti.r.ready := state === s_REFILL
@@ -136,11 +135,11 @@ class Cache(implicit val p: Parameters) extends Module with CacheParams {
 
   // write addr
   io.nasti.aw.bits := NastiWriteAddressChannel(
-    0.U, Cat(rmeta.tag, idx_reg) << blen.U, log2Up(nastiXDataBits/8).U, (dataBeats-1).U)
+    0.U, (Cat(rmeta.tag, idx_reg) << blen.U).asUInt, log2Up(nastiXDataBits/8).U, (dataBeats-1).U)
   io.nasti.aw.valid := false.B
   // write data
   io.nasti.w.bits := NastiWriteDataChannel(
-    Vec.tabulate(dataBeats)(i => read((i+1)*nastiXDataBits-1, i*nastiXDataBits))(write_count),
+    VecInit.tabulate(dataBeats)(i => read((i+1)*nastiXDataBits-1, i*nastiXDataBits))(write_count),
     None, write_wrap_out)
   io.nasti.w.valid := false.B
   // write resp

--- a/src/main/scala/Control.scala
+++ b/src/main/scala/Control.scala
@@ -147,7 +147,7 @@ class Control(implicit p: Parameters) extends Module {
 
   // Control signals for Fetch
   io.pc_sel    := ctrlSignals(0)
-  io.inst_kill := ctrlSignals(6).toBool 
+  io.inst_kill := ctrlSignals(6).asBool
 
   // Control signals for Execute
   io.A_sel   := ctrlSignals(1)
@@ -160,7 +160,7 @@ class Control(implicit p: Parameters) extends Module {
   // Control signals for Write Back
   io.ld_type := ctrlSignals(8)
   io.wb_sel  := ctrlSignals(9)
-  io.wb_en   := ctrlSignals(10).toBool
+  io.wb_en   := ctrlSignals(10).asBool
   io.csr_cmd := ctrlSignals(11)
   io.illegal := ctrlSignals(12)
 }

--- a/src/main/scala/Datapath.scala
+++ b/src/main/scala/Datapath.scala
@@ -48,7 +48,7 @@ class Datapath(implicit val p: Parameters) extends Module with CoreParams {
   val pc_check = Reg(Bool())
  
   /****** Fetch *****/
-  val started = RegNext(reset.toBool)
+  val started = RegNext(reset.asBool)
   val stall = !io.icache.resp.valid || !io.dcache.resp.valid
   val pc   = RegInit(Const.PC_START.U(xlen.W) - 4.U(xlen.W))
   val npc  = Mux(stall, pc, Mux(csr.io.expt, csr.io.evec,
@@ -114,7 +114,7 @@ class Datapath(implicit val p: Parameters) extends Module with CoreParams {
     ST_SB -> ("b1".U  << alu.io.sum(1,0))))
   
   // Pipelining
-  when(reset.toBool || !stall && csr.io.expt) {
+  when(reset.asBool || !stall && csr.io.expt) {
     st_type   := 0.U
     ld_type   := 0.U
     wb_en     := false.B

--- a/src/test/scala/TileTests.scala
+++ b/src/test/scala/TileTests.scala
@@ -37,7 +37,7 @@ class TileTester(
   val dut = Module(tile)
   // Connect black box clock
   dut match {
-    case bbox: core.BaseBlackBox =>
+    case bbox: BlackBox =>
       bbox.clock := clock
     case _ =>
   }
@@ -61,7 +61,7 @@ class TileTester(
   val bpipe = WireInit(dut.io.nasti.b)
   val rpipe = WireInit(dut.io.nasti.r)
 
-  dut.reset := reset.toBool || state === sInit
+  dut.reset := reset.asBool || state === sInit
   dut.io.nasti.aw.ready := state === sIdle
   dut.io.nasti.ar.ready := state === sIdle 
   dut.io.nasti.w.ready  := state === sWrite


### PR DESCRIPTION
Replace old chisel2 contructs.
Update deprecations.
Set default chisel version to 3.2-SNAPSHOT