### PR TITLE
Minimal clone of updated verilator version (4.016)

### DIFF
--- a/.install_verilator.sh
+++ b/.install_verilator.sh
@@ -2,11 +2,9 @@ set -e
 # Install Verilator (http://www.veripool.org/projects/verilator/wiki/Installing)
 if [ ! -f $INSTALL_DIR/bin/verilator ]; then 
   mkdir -p $INSTALL_DIR
-  git clone http://git.veripool.org/git/verilator
+  git clone --branch v4.016 --depth 1 http://git.veripool.org/git/verilator
   unset VERILATOR_ROOT
   cd verilator
-  git pull
-  git checkout verilator_3_886
   autoconf
   ./configure --prefix=$INSTALL_DIR
   make


### PR DESCRIPTION
The Travis build was failing with:
```
error: pathspec 'verilator_3_886' did not match any file(s) known to git
```
proably due to the fact that the .travis.yml file contains:
```
git:
  depth: 10
```
and `verilator_3_886` may be too far back in history.
Clone at the specific (updated) verilator tag we expect to run to avoid depth issues.