### PR TITLE
Fix: Default make recipe not dump firrtl file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ sbt:
 compile: $(gen_dir)/Tile.sv
 
 $(gen_dir)/Tile.sv: $(wildcard $(src_dir)/scala/*.scala)
-	$(SBT) $(SBT_FLAGS) "run --target-dir=$(gen_dir)"
+	$(SBT) $(SBT_FLAGS) "run --target-dir=$(gen_dir) --dump-fir"
 
 CXXFLAGS += -std=c++14 -Wall -Wno-unused-variable
 


### PR DESCRIPTION
According to README in riscv-mini, running `make` would dump .fir firrtl file and .sv file. But there is only a SystemVerilog file output in the generated dir.

Some projects maybe relies to this behavior to work, such as ussc-vama/essent-chisel-gallery.

So I append a flag to SBT to avoid some potential issue. Running `make` will also generate firrtl file now.